### PR TITLE
fix(deploy): moves postdeploy to `Procfile`

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python bot.py

--- a/app.json
+++ b/app.json
@@ -1,6 +1,3 @@
 {
-  "name": "Meetbot",
-  "scripts": {
-    "postdeploy": "python tasks/post-deploy.py"
-  }
+  "name": "Meetbot"
 }

--- a/bot.py
+++ b/bot.py
@@ -1,3 +1,5 @@
+import tasks.post_deploy
+
 from os import environ
 from slackclient import SlackClient
 

--- a/tasks/post_deploy.py
+++ b/tasks/post_deploy.py
@@ -3,4 +3,4 @@ from slackclient import SlackClient
 
 sc = SlackClient(environ['SLACK_BOT_TOKEN'])
 sc.rtm_connect()
-sc.rtm_send_message('general', 'A new version of @meetbot has been deployed!')
+sc.rtm_send_message('meetify', 'A new version of @meetbot has been deployed!')


### PR DESCRIPTION
it seems like `postdeploy` on `app.json` only
runs when the app is first created (so only once
EVER). this should run it on every deploy